### PR TITLE
Add validation for amounts and addresses

### DIFF
--- a/app/components/Delegate.js
+++ b/app/components/Delegate.js
@@ -13,7 +13,7 @@ import tezosLogo from '../../resources/tezosLogo.png';
 import {
   updatePassword,
   updateAddress,
-  openConfirmationModal,
+  showConfirmationModal,
   closeConfirmationModal,
   sendConfirmation,
   setOriginalAddress
@@ -102,7 +102,7 @@ class Delegate extends Component<Props> {
   };
 
   render() {
-    const { address, openConfirmationModal, updateAddress } = this.props;
+    const { address, showConfirmationModal, updateAddress } = this.props;
 
     return (
       <Container>
@@ -113,7 +113,7 @@ class Delegate extends Component<Props> {
         />
 
         <UpdateButton
-          onClick={openConfirmationModal}
+          onClick={showConfirmationModal}
           buttonTheme="secondary"
           small
         >
@@ -143,7 +143,7 @@ function mapDispatchToProps(dispatch) {
     {
       updatePassword,
       updateAddress,
-      openConfirmationModal,
+      showConfirmationModal,
       closeConfirmationModal,
       sendConfirmation,
       setOriginalAddress

--- a/app/components/Send.js
+++ b/app/components/Send.js
@@ -12,7 +12,7 @@ import {
   updateToAddress,
   updateAmount,
   updateFee,
-  openSendTezosModal,
+  showConfirmation,
   closeSendTezosModal,
   sendConfirmation
 } from '../reducers/sendTezos.duck';
@@ -37,7 +37,7 @@ type Props = {
   updateToAddress: Function,
   updateAmount: Function,
   updateFee: Function,
-  openSendTezosModal: Function,
+  showConfirmation: Function,
   closeSendTezosModal: Function,
   sendConfirmation: Function,
   isConfirmationModalOpen: boolean,
@@ -61,7 +61,7 @@ class Send extends Component<Props> {
       updateAmount,
       updatePassword,
       updateFee,
-      openSendTezosModal,
+      showConfirmation,
       closeSendTezosModal,
       sendConfirmation
     } = this.props;
@@ -92,7 +92,7 @@ class Send extends Component<Props> {
             <MenuItem value={500} primaryText="Custom" />
           </SelectField>
         </AmountContainer>
-        <Button onClick={openSendTezosModal} buttonTheme="secondary" small>
+        <Button onClick={showConfirmation} buttonTheme="secondary" small>
           Send
         </Button>
         <SendConfirmationModal
@@ -130,8 +130,8 @@ const mapDispatchToProps = dispatch =>
       updateToAddress,
       updateAmount,
       updateFee,
-      openSendTezosModal,
       closeSendTezosModal,
+      showConfirmation,
       sendConfirmation
     },
     dispatch

--- a/app/containers/AddressPage.js
+++ b/app/containers/AddressPage.js
@@ -19,6 +19,7 @@ import {
   updateUsername,
   updatePassPhrase,
   confirmPassPhrase,
+  passPhrase,
   updateSeed,
   selectDefaultAccountOrOpenModal
 } from '../reducers/address.duck';

--- a/app/reducers/address.duck.js
+++ b/app/reducers/address.duck.js
@@ -8,7 +8,7 @@ import { tezosWallet, tezosQuery } from '../conseil';
 import { saveUpdatedWallet } from './walletInitialization.duck';
 import { addMessage } from './message.duck';
 import { changeDelegate, addParentKeysToAccounts } from './createAccount.duck';
-import hasError from '../utils/formValidation';
+import { displayError } from '../utils/formValidation';
 
 const {
   getOperationGroups,
@@ -32,8 +32,8 @@ const CLEAR_STATE = 'CLEAR_STATE';
 const UPDATE_PRIVATE_KEY = 'UPDATE_PRIVATE_KEY';
 const UPDATE_PUBLIC_KEY = 'UPDATE_PUBLIC_KEY';
 const UPDATE_USERNAME = 'UPDATE_USERNAME';
-const UPDATE_PASS_PHRASE = 'UPDATE_PASS_PHRASE';
-const CONFIRM_PASS_PHRASE = 'CONFIRM_PASS_PHRASE';
+const UPDATE_PASS_PHRASE = 'UPDATE_ADDRESS_PASS_PHRASE';
+const CONFIRM_PASS_PHRASE = 'CONFIRM_ADDRESS_PASS_PHRASE';
 const UPDATE_SEED = 'UPDATE_SEED';
 const ADD_NEW_IDENTITY = 'ADD_NEW_IDENTITY';
 const ADD_NEW_ACCOUNT = 'ADD_NEW_ACCOUNT';
@@ -254,13 +254,13 @@ export function importAddress() {
     dispatch(addMessage('', true));
 
     if ( activeTab === GENERATE_MNEMONIC ) {
-      let error = hasError(passPhrase, 'minLength8');
-      if ( error ) {
-        return dispatch(addMessage(error, true));
-      }
+      const validations = [
+        { value: passPhrase, type: 'minLength8', name: 'Pass Phrase'},
+        { value: [passPhrase, confirmedPassPhrase], type: 'samePassPhrase'},
+      ];
 
-      error = hasError([passPhrase, confirmedPassPhrase], 'samePassPhrase');
-      if ( error ) {
+      const error = displayError(validations);
+      if (error) {
         return dispatch(addMessage(error, true));
       }
     }

--- a/app/reducers/createAccount.duck.js
+++ b/app/reducers/createAccount.duck.js
@@ -4,7 +4,7 @@ import { tezosOperations, tezosQuery } from '../conseil';
 import actionCreator from '../utils/reduxHelpers';
 import { addNewAccount } from './address.duck';
 import { addMessage } from './message.duck';
-import hasError from '../utils/formValidation';
+import { displayError } from '../utils/formValidation';
 
 const { getAccount } = tezosQuery;
 const { sendOriginationOperation } = tezosOperations;
@@ -54,16 +54,17 @@ export function createNewAccount() {
     const network = state().walletInitialization.get('network');
 
     const validations = [
-      { value: passPhrase, type: 'notEmpty' },
-      { value: passPhrase, type: 'minLength8' },
+      { value: amount, type: 'notEmpty', name: 'Amount'},
+      { value: amount, type: 'validAmount'},
+      { value: amount, type: 'notZero', name: 'Amount'},
+      { value: passPhrase, type: 'notEmpty', name: 'Pass Phrase'},
+      { value: passPhrase, type: 'minLength8', name: 'Pass Phrase' },
       { value: [passPhrase, confirmedPassPhrase], type: 'samePassPhrase' }
     ];
 
-    for (let i = 0; i < validations.length; i++) {
-      const error = hasError(validations[i].value, validations[i].type);
-      if (error) {
-        return dispatch(addMessage(error, true));
-      }
+    const error = displayError(validations);
+    if (error) {
+      return dispatch(addMessage(error, true));
     }
 
     try {
@@ -124,7 +125,9 @@ const initState = fromJS({
   fee: 100,
   isLoading: false,
   isModalOpen: false,
-  operation: ''
+  operation: '',
+  passPhrase: '',
+  confirmedPassPhrase: ''
 });
 
 export default function createAccount(state = initState, action) {

--- a/app/reducers/delegate.duck.js
+++ b/app/reducers/delegate.duck.js
@@ -4,6 +4,7 @@ import actionCreator from '../utils/reduxHelpers';
 import request from '../utils/request';
 import { addMessage } from './message.duck';
 import { sendDelegationOperation } from '../tezos/TezosOperations';
+import { displayError } from '../utils/formValidation';
 
 /* ~=~=~=~=~=~=~=~=~=~=~=~= Constants ~=~=~=~=~=~=~=~=~=~=~=~=~=~=~= */
 const UPDATE_DELEGATE_URL = 'UPDATE_DELEGATE_URL';
@@ -23,6 +24,24 @@ const updateIsLoading = actionCreator(UPDATE_DELEGATE_IS_LOADING, 'isLoading');
 const clearState = actionCreator(CLEAR_STATE);
 
 /* ~=~=~=~=~=~=~=~=~=~=~=~= Thunks ~=~=~=~=~=~=~=~=~=~=~=~=~=~=~= */
+export function showConfirmationModal() {
+  return async (dispatch, state) => {
+    const address = state().delegate.get('address');
+
+    const validations = [
+      { value: address, type: 'notEmpty', name: 'Address'},
+      { value: address, type: 'validAddress'},
+    ];
+
+    const error = displayError(validations);
+    if (error) {
+      return dispatch(addMessage(error, true));
+    }
+
+    dispatch(openConfirmationModal());
+  }
+
+}
 export function setOriginalAddress() {
   return async (dispatch, state) => {
     const walletState = state().walletInitialization;

--- a/app/reducers/sendTezos.duck.js
+++ b/app/reducers/sendTezos.duck.js
@@ -4,6 +4,7 @@ import actionCreator from '../utils/reduxHelpers';
 import { sendTransactionOperation } from '../tezos/TezosOperations';
 import { addMessage } from './message.duck';
 import { findKeyStore } from './createAccount.duck';
+import { displayError } from '../utils/formValidation';
 
 /* ~=~=~=~=~=~=~=~=~=~=~=~= Constants ~=~=~=~=~=~=~=~=~=~=~=~=~=~=~= */
 const UPDATE_PASSWORD = 'UPDATE_PASSWORD';
@@ -29,6 +30,27 @@ const updateSendTezosLoading = actionCreator(
 const clearState = actionCreator(CLEAR_STATE);
 
 /* ~=~=~=~=~=~=~=~=~=~=~=~= Thunks ~=~=~=~=~=~=~=~=~=~=~=~=~=~=~= */
+
+export function showConfirmation() {
+  return async (dispatch, state) => {
+    const toAddress = state().sendTezos.get('toAddress');
+    const amount = state().sendTezos.get('amount');
+
+    const validations = [
+      { value: amount, type: 'notEmpty', name: 'Amount'},
+      { value: amount, type: 'validAmount'},
+      { value: amount, type: 'notZero', name: 'Amount'},
+      { value: toAddress, type: 'validAddress'}
+    ];
+
+    const error = displayError(validations);
+    if (error) {
+      return dispatch(addMessage(error, true));
+    }
+
+    dispatch(openSendTezosModal(true));
+  }
+}
 export function sendConfirmation() {
   return async (dispatch, state) => {
     const sendTezosState = state().sendTezos;

--- a/app/reducers/walletInitialization.duck.js
+++ b/app/reducers/walletInitialization.duck.js
@@ -7,7 +7,7 @@ import { clearEntireAddressState } from './address.duck';
 import { addMessage } from './message.duck';
 import actionCreator from '../utils/reduxHelpers';
 import CREATION_CONSTANTS from '../constants/CreationTypes';
-import hasError from '../utils/formValidation';
+import { displayError } from '../utils/formValidation';
 
 const { createWallet, loadWallet, saveWallet } = tezosWallet;
 
@@ -90,13 +90,13 @@ export function submitAddress(submissionType: 'create' | 'import') {
     dispatch(addMessage('', true));
 
     if ( submissionType === 'create' ) {
-      let error = hasError(walletLocation, 'locationFilled');
-      if ( error ) {
-        return dispatch(addMessage(error, true));
-      }
+      const validations = [
+        { value: walletLocation, type: 'locationFilled'},
+        { value: password, type: 'minLength8', name: 'Password'},
+      ];
 
-      error = hasError(password, 'minLength8');
-      if ( error ) {
+      const error = displayError(validations);
+      if (error) {
         return dispatch(addMessage(error, true));
       }
     }

--- a/app/utils/formValidation.js
+++ b/app/utils/formValidation.js
@@ -1,5 +1,20 @@
-function minLength(length) {
-  return `Pass Phrase must be at least ${length} characters.`
+function minLength(length, name) {
+  return `${name} must be at least ${length} characters.`
+}
+
+function hasLength(length, name) {
+  return `${name} must be exactly ${length} characters.`
+}
+
+export function displayError(validations) {
+  for (let i = 0; i < validations.length; i++) {
+    const error = hasError(validations[i].value, validations[i].type, validations[i].name);
+    if (error) {
+      return error;
+    }
+  }
+
+  return false;
 }
 /**
  * 
@@ -7,11 +22,29 @@ function minLength(length) {
  * @param validateType { string }
  * @returns { false | string }
  */
-export default function hasError(value, validateType) {
+export default function hasError(value, validateType, name) {
   switch(validateType) {
+    case 'validAmount':
+      if ( !/^(\d+|\d{1,3}(,\d{3})*)(\.\d+)?$/.test(value)) {
+        return `Amount is not valid.`;
+      }
+      break;
+    case 'validAddress':
+      if ( value.length < 36 ) {
+        return hasLength(36, 'Address');
+      }
+      if ( !RegExp('^tz1|^TZ1').test(value)) {
+        return `Address must begin with tz1 or TZ1.`;
+      }
+      break;
+    case 'notZero':
+      if ( parseInt(value) == 0 ) {
+        return `${name} cannot equal 0.`;
+      }
+      break;
     case 'notEmpty':
-      if (!value) {
-        return 'Must not be empty';
+      if ( !value ) {
+        return `${name} must not be empty.`;
       }
       break;
     case 'locationFilled':
@@ -21,7 +54,7 @@ export default function hasError(value, validateType) {
       break;
     case 'minLength8': 
       if ( value.length < 8 ) {
-        return minLength(8);
+        return minLength(8, name);
       }
       break;
     case 'samePassPhrase':
@@ -30,7 +63,7 @@ export default function hasError(value, validateType) {
       }
 
       if ( value[0] !== value[1] ) {
-        return 'Passphrases must be equal.';
+        return 'Pass phrases must be equal.';
       }
       break;
   }


### PR DESCRIPTION
Issue: https://github.com/Cryptonomic/Tezos-Wallet/issues/21
Where:
- "Add account" modal - "Amount" field
- "Send" tab - "Amount" field
- "Send" tab - "Address" field
- "Delegate" tab - "Address" field

Also affects:
- All other validation-based transactions across site

Solution:
- Address and amount validation for "Send" tab before opening up confirmation modal
- Address validation for "Delegate" tab before opening up confirmation modal
- Amount validation - "not empty", "not zero", "valid"
- Address validation - "36 characters", "tz1 || TZ1 only"
- Field names are dynamic in error messaging "Password" vs "Pass Phrase"

![](http://g.recordit.co/XOP6hKv3Sn.gif)
![](http://g.recordit.co/PweDgP2I6h.gif)