### PR TITLE
Polish/consistent prompts

### DIFF
--- a/app/components/AccountStatus/Info.js
+++ b/app/components/AccountStatus/Info.js
@@ -58,11 +58,7 @@ function Info(props: Props) {
         color="accent"
         iconName={ firstIconName }
       />
-      <ActivationOperation
-        onClick={ () => {
-          openLinkToBlockExplorer(operationId);
-        }}
-      >
+      <ActivationOperation>
         { operationName }
       </ActivationOperation>
       <ActivationOperationId>

--- a/app/components/AccountStatus/Info.js
+++ b/app/components/AccountStatus/Info.js
@@ -27,7 +27,6 @@ const ActivationOperation = styled.div`
   text-transform: uppercase;
   margin-left: 5px;
   margin-right: 5px;
-  cursor: pointer;
 `;
 
 const ActivationOperationId = styled.div`

--- a/app/components/AccountStatus/index.js
+++ b/app/components/AccountStatus/index.js
@@ -77,8 +77,8 @@ function AccountStatus(props: Props) {
     case statuses.CREATED:
       if ( storeTypes === MNEMONIC ) {
         icon = <Image alt={'Creating account'} src={transactionsEmptyState} />;
-        title = 'Your account is currently not ready.';
-        description = 'The first transaction will get your account ready to send and delegate. Getting your account ready after your first transaction might take a while.';
+        title = 'Your account is ready to receive transactions!';
+        description = 'Your first transaction will commit your new address to the blockchain. This process may take some time until you are all set to send and delegate.';
       } else {
         title = `Retrieving your ${ typeText }...`;
         if ( operations[ statuses.CREATED ] ) {

--- a/app/components/AccountStatus/index.js
+++ b/app/components/AccountStatus/index.js
@@ -39,6 +39,8 @@ const Icon = styled.div`
 
 const Title = styled(H4)`
   font-weight: normal;
+  font-size: 1.2rem;
+  padding-bottom: .2rem
 `;
 
 const Description = styled.div`

--- a/app/components/AddDelegateModal/index.js
+++ b/app/components/AddDelegateModal/index.js
@@ -158,7 +158,7 @@ class AddDelegateModal extends Component<Props> {
         </div>
         <div className={styles.amountAndFeeContainer}>
           <TextField
-            floatingLabelText="Password"
+            floatingLabelText="Wallet Password"
             type="password"
             style={{ width: '100%' }}
             onChange={this.updatePassPhrase}

--- a/app/components/Delegate/index.js
+++ b/app/components/Delegate/index.js
@@ -196,7 +196,7 @@ class Delegate extends Component<Props> {
     const delegationTips = [
       'Delegating tez is not the same as sending tez. Only baking rights are transferred when setting a delegate. The delegate that you set cannot spend your tez.',
       'There is a fee for setting a delegate.',
-      'Delegating is not instant. It takes 7 cycles (~20 days) for your tez to start contributing to baking.',
+      'It takes 7 cycles (~20 days) for your tez to start contributing to baking.',
       'Delegation rewards will depend on your arrangement with the delegate.'
     ];
 

--- a/app/components/SendConfirmationModal.js
+++ b/app/components/SendConfirmationModal.js
@@ -93,7 +93,7 @@ const SendConfirmationModal = props => {
       </AmountContainer>
       <PaswordContainer>
         <TextField
-          floatingLabelText="Enter Wallet Password"
+          floatingLabelText="Wallet Password"
           style={{ width: '60%' }}
           type="password"
           value={password}

--- a/app/components/Transaction/index.js
+++ b/app/components/Transaction/index.js
@@ -42,7 +42,7 @@ const StateText = styled.div`
     font-size: 12px;
     color: ${ ({ theme: { colors } }) => colors.gray6 };
     margin: 0 6px;
-  }  
+  }
 `
 const AddressText = styled.div`
   color: ${ ({ theme: { colors } }) => colors.black2 };
@@ -97,11 +97,11 @@ const getStatus = (transaction, selectedAccountHash) => {
   const isAmount = getIsAmount(transaction.amount);
 
   if (type === 'origination' && isSameLocation) {
-    return {icon: 'send', preposition: 'of', state: 'ORIGINATION', isFee, color: isAmount? 'error1': 'gray8', sign: isAmount? '-': ''};
+    return {icon: 'send', preposition: '', state: 'ORIGINATION', isFee, color: isAmount? 'error1': 'gray8', sign: isAmount? '-': ''};
   }
 
   if (type === 'origination' && !isSameLocation) {
-    return {icon: 'receive', preposition: 'from', state: 'ORIGINATION', isFee, color: isAmount? 'check': 'gray8', sign: isAmount? '+': ''};
+    return {icon: 'receive', preposition: '', state: 'ORIGINATION', isFee, color: isAmount? 'check': 'gray8', sign: isAmount? '+': ''};
   }
 
   if (type === 'transaction' && isSameLocation) {
@@ -120,7 +120,7 @@ const getAddress = (transaction, selectedAccountHash, selectedParentHash) => {
     return <AddressText>this address</AddressText>;
   }
   if (type === 'origination' && transaction.source === selectedParentHash && selectedAccountHash !== selectedParentHash) {
-      return <AddressText><span>your</span>&nbsp;Account 1 Manager Address</AddressText>;  
+      return <AddressText><span>your</span>&nbsp;Account 1 Manager Address</AddressText>;
   }
   if (!address) {
     return null;
@@ -162,7 +162,7 @@ const Transaction = (props: Props) => {
         </AmountContainer>
       </Header>
       <Container>
-        <ContentDiv>        
+        <ContentDiv>
           <StateIcon
             iconName={icon}
             size={ms(-2)}
@@ -180,7 +180,7 @@ const Transaction = (props: Props) => {
           />
 
         </ContentDiv>
-        {isFee && 
+        {isFee &&
           <Fee>
             <span>Fee: </span>
             <TezosAmount
@@ -191,7 +191,7 @@ const Transaction = (props: Props) => {
             />
           </Fee>
         }
-      </Container>       
+      </Container>
     </TransactionContainer>
   )
 }

--- a/app/components/Transaction/index.js
+++ b/app/components/Transaction/index.js
@@ -85,7 +85,7 @@ const getIsAmount = (amount) => !!amount;
 const getStatus = (transaction, selectedAccountHash) => {
   const type = transaction.kind;
   if (type === 'reveal') {
-    return {icon: 'broadcast', preposition: 'of', state: 'KEY REVEAL', isFee: false, color: 'gray8', sign: ''};
+    return {icon: 'broadcast', preposition: 'of', state: 'PUBLIC KEY REVEAL', isFee: false, color: 'gray8', sign: ''};
   }
 
   if (type === 'activation') {


### PR DESCRIPTION
There were still inconsistent prompts with Wallet Password, fixed them

Changed the account not ready message

Removed the link from the activation operation to make it consistent with transactions tab

Removed prepositions from Origination operation