### PR TITLE
feat/505-determine-burn

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,8 +16,7 @@
   "license": "MIT",
   "dependencies": {
     "@ledgerhq/hw-transport-node-hid": "^4.24.0",
-    "conseiljs": "^0.1.36",
-    "conseiljs-staging": "https://a944a75da6e29dc79252b34830eb28ea8b0dbe8b:x-oauth-basic@github.com/Cryptonomic/ConseilJS.git#staging-two",
+    "conseiljs": "https://a944a75da6e29dc79252b34830eb28ea8b0dbe8b:x-oauth-basic@github.com/Cryptonomic/ConseilJS.git#staging",
     "react-currency-input": "^1.3.6"
   }
 }

--- a/app/reduxContent/wallet/thunks.js
+++ b/app/reduxContent/wallet/thunks.js
@@ -568,3 +568,16 @@ export function getIsReveal(selectedAccountHash, selectedParentHash) {
     return isReveal;
   };
 }
+
+export function getIsImplicitAndEmpty(recipientHash) {
+  return async (dispatch, state) => {
+    const settings = state().settings.toJS();
+    const { url } = getSelectedNode(settings, TEZOS);
+
+    const isImplicitAndEmpty = await TezosOperations.isImplicitAndEmpty(
+      url,
+      recipientHash
+    );
+    return isImplicitAndEmpty;
+  };
+}


### PR DESCRIPTION
added getIsImplicitAndEmpty function to wallet thunks;

if true, transaction operation will require a burn
if false, transaction operation will not require a burn