### PR TITLE
Feat/506 allow emptying out via origination

### DIFF
--- a/app/components/AddDelegateModal/index.js
+++ b/app/components/AddDelegateModal/index.js
@@ -236,11 +236,11 @@ class AddDelegateModal extends Component<Props> {
   onUseMax = () => {
     const { managerBalance } = this.props;
     const { fee, gas } = this.state;
-    const max = managerBalance - fee - gas - 1;
+    const max = managerBalance - fee - gas;
     if (max > 0) {
       const amount = (max / utez).toFixed(6);
-      const total = managerBalance - 1;
-      const balance = 1;
+      const total = managerBalance;
+      const balance = 0;
       this.setState({ amount, total, balance });
     } else {
       const amount = '0';
@@ -339,13 +339,6 @@ class AddDelegateModal extends Component<Props> {
         balanceColor: 'error1'
       };
     }
-    if (balance === 0) {
-      return {
-        isIssue: true,
-        warningMessage: t('components.addDelegateModal.warning2'),
-        balanceColor: 'error1'
-      };
-    }
 
     if (amount) {
       return {
@@ -392,7 +385,7 @@ class AddDelegateModal extends Component<Props> {
       !delegate ||
       !amount ||
       (!passPhrase && !isLedger) ||
-      balance < 1 ||
+      balance < 0 ||
       isDelegateIssue;
     const { isIssue, warningMessage, balanceColor } = this.getBalanceState(
       balance,


### PR DESCRIPTION
Emptying out via `Send` has been merged with #514 
This PR allows implicit accounts to empty out their funds via `origination`