### PR TITLE
Removed unused USDtz balance

### DIFF
--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -47,7 +47,6 @@ export function Wallet() {
                 <h1>Wallet</h1>
                 <p>Delegate: {walletState.delegate}</p>
                 <p>XTZ Balance: {walletState.balance}</p>
-                <p>USDtz Balance: N/A</p>
             </div>
     );
 }


### PR DESCRIPTION
Closes #741 

- Removed USDtz balance line from the wallet component, as it was not being used
- Below is a screenshot of the result of this deletion:

<img width="460" alt="Screen Shot 2022-06-09 at 6 06 40 PM" src="https://user-images.githubusercontent.com/105510288/172958203-9189824d-cf04-48db-85cb-a4f8d2675223.png">
