### PR TITLE
Show derivation path in settings component

### DIFF
--- a/src/components/AddressBar.tsx
+++ b/src/components/AddressBar.tsx
@@ -31,7 +31,7 @@ export function AddressBar() {
         }
 
         if(ledgerAppXtz) {
-            const address = await ledgerAppXtz.getAddress("44'/1729'/0'/0'")
+            const address = await ledgerAppXtz.getAddress(globalState.derivationPath)
             console.log("address", address)
             setAddress(address.address)
         }

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -13,6 +13,8 @@ export function Settings() {
             <input id={"settings_apikey"} defaultValue={globalState.apiKey} />
             <p>Network</p>
             <input id={"settings_apikey"} defaultValue={globalState.network} />
+            <p>Derivation Path</p>
+            <input id={"settings_derivationPath"} defaultValue={globalState.derivationPath} />
         </div>
     );
 }


### PR DESCRIPTION
- In the Address Bar, switched from using a hard-coded value to using `derivationPath` (stored in `globalState`) 
- Displayed `derivationPath` in Settings component

Below is a screenshot with the additions described above:
<img width="479" alt="Screen Shot 2022-06-10 at 2 30 31 PM" src="https://user-images.githubusercontent.com/105510288/173128438-ee9473f1-33a3-4b2c-b416-f6620c03dd88.png">

Closes #743.