### PR TITLE
Electron funcionality for MacOS

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -27,7 +27,7 @@ function createWindow () {
     mainWindow = null;
   });
 
-  mainWindow.webContents.on('new-window', (event: Event, url: string) => {
+  mainWindow.webContents.on('new-window', (event, url) => {
     event.preventDefault();
     mainWindow.loadURL(url);
   });
@@ -50,4 +50,3 @@ app.on('window-all-closed', () => {
   }
 });
 
-export {}


### PR DESCRIPTION
- Electron.js can run Tezori on MacOS
- Certain functions/objects in `main.ts`, the file that runs the app in Electron, were not compatible with the type of file `main.ts` is, leading to contradictory errors
- I deleted the offending lines, as they seemed to have no purpose in the file 
- Below is a screenshot of Electron running Tezori:

<img width="1439" alt="Electron on Mac" src="https://user-images.githubusercontent.com/105510288/176189379-7a1ffe1b-65d2-43ee-b10a-d82de13e30a9.png">

